### PR TITLE
Allow Fencer to describe arrays

### DIFF
--- a/lib/fencer.rb
+++ b/lib/fencer.rb
@@ -61,9 +61,11 @@ module Fencer
     end
     
     private
-    
-    def parse!      
-      if @delimiter
+
+    def parse!
+      if @str.kind_of?(Array)
+        raw_values = @str
+      elsif @delimiter
         raw_values = @str.split(@delimiter)
       else
         unpack_phrase = self.class.fields.values.map { |s| "A#{s[:size]}" }.join
@@ -81,9 +83,9 @@ module Fencer
           
           @values[name] = _conversion_proc ? _conversion_proc.call(raw_values[_index]) : raw_values[_index]
         end
-        
-        _index += 1 unless opts[:space] && @delimiter
-      end      
-    end    
+
+        _index += 1 unless opts[:space] && (@delimiter || @str.kind_of?(Array))
+      end
+    end
   end
 end

--- a/spec/fencer_spec.rb
+++ b/spec/fencer_spec.rb
@@ -68,7 +68,21 @@ describe Fencer do
     values.department.should eq(department)
     values.employment_date.should eq("2012-05-25")
     values.id_number.should eq(id_number.to_i)
-    values.leave_accrued.should eq(BigDecimal(leave_accrued))    
+    values.leave_accrued.should eq(BigDecimal(leave_accrued))
+  end
+
+  it "also describes arrays!" do
+    compiled_record = [
+      name, department, employment_date, id_number, leave_accrued
+    ]
+
+    values = EmployeeRecord.new(compiled_record)
+
+    values.name.should eq(name)
+    values.department.should eq(department)
+    values.employment_date.should eq("2012-05-25")
+    values.id_number.should eq(id_number.to_i)
+    values.leave_accrued.should eq(BigDecimal(leave_accrued))
   end
 end
 


### PR DESCRIPTION
This is useful because we can allow the CSV library to parse delimited rows in our code and use the values prior to fencing them (I quite often see the use case where the Fence we are using is based on one of the fields contained inside the row).
